### PR TITLE
INTERLOK-3035 Suppport connection retry

### DIFF
--- a/src/test/java/com/adaptris/core/mongodb/MongoDBConnectionTest.java
+++ b/src/test/java/com/adaptris/core/mongodb/MongoDBConnectionTest.java
@@ -1,8 +1,12 @@
 package com.adaptris.core.mongodb;
 
+import com.adaptris.util.TimeInterval;
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
@@ -34,5 +38,21 @@ public class MongoDBConnectionTest {
     assertNull(connection.getDatabase());
     connection.setDatabase("database");
     assertEquals("database", connection.getDatabase());
+  }
+
+  @Test
+  public void testConnectionFailure() {
+    MongoDBConnection connection = new MongoDBConnection("mongodb://localhost:27017", "database");
+    connection.setConnectionAttempts(5);
+    connection.setConnectionRetryInterval(new TimeInterval(5L, TimeUnit.SECONDS));
+    try {
+      connection.initConnection();
+
+      assertNotNull(connection.retrieveMongoClient());
+      assertNotNull(connection.retrieveMongoDatabase());
+    } catch (Exception e) {
+      // expected (unless you actually fire-up a MongoDB instance
+    }
+
   }
 }


### PR DESCRIPTION
## Motivation

It all come from a question from Orange:

> If the interlok starts before mongodb, the workflow fails to initiate

## Modification

The `MongoDBConnection` now extends `AllowsRetriesConnection` and adds a private method `attemptConnect` to retry the connection (as necessary).

## Result

If the connection cannot be made straight away, after a short delay another attempt is made, up to the configured limit.

## Testing

The unit tests do not cover everything (they're not spinning up a MongoDB instance) but with your own local instance, the connection can be configured as used as before with the added bonus of retrying if it doesn't success at first.
