### PR TITLE
INTERLOK-3566 Remove references to Destination

### DIFF
--- a/src/test/java/com/adaptris/core/mongodb/MongoDBAggregateProducerTest.java
+++ b/src/test/java/com/adaptris/core/mongodb/MongoDBAggregateProducerTest.java
@@ -16,25 +16,26 @@
 
 package com.adaptris.core.mongodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import java.util.Arrays;
-import org.bson.Document;
-import org.junit.Before;
-import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ConfiguredDestination;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.StringPayloadDataInputParameter;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.mongodb.client.AggregateIterable;
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author mwarman
@@ -93,7 +94,7 @@ public class MongoDBAggregateProducerTest extends MongoDBCase {
     producer.registerConnection(connection);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(PIPELINE);
     LifecycleHelper.initAndStart(producer);
-    producer.request(msg, new ConfiguredDestination("collection"), TIMEOUT.toMilliseconds());
+    producer.request(msg, TIMEOUT.toMilliseconds());
     String result = msg.getContent();
     assertJsonArraySize(result, 2);
     LifecycleHelper.stopAndClose(producer);

--- a/src/test/java/com/adaptris/core/mongodb/MongoDBDeleteProducerTest.java
+++ b/src/test/java/com/adaptris/core/mongodb/MongoDBDeleteProducerTest.java
@@ -16,19 +16,20 @@
 
 package com.adaptris.core.mongodb;
 
-import static org.junit.Assert.assertEquals;
-import java.util.ArrayList;
-import java.util.Arrays;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.util.LifecycleHelper;
+import com.mongodb.client.MongoCollection;
 import org.bson.Document;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ConfiguredDestination;
-import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.util.LifecycleHelper;
-import com.mongodb.client.MongoCollection;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author mwarman
@@ -57,7 +58,7 @@ public class MongoDBDeleteProducerTest extends MongoDBCase {
     producer.registerConnection(connection);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("[ {\"key\": 1},{\"key\": 2}]");
     LifecycleHelper.initAndStart(producer);
-    producer.produce(msg, new ConfiguredDestination(COLLECTION));
+    producer.produce(msg);
     if(localTests){
       assertRecordsArePresent(0);
     } else {
@@ -72,7 +73,7 @@ public class MongoDBDeleteProducerTest extends MongoDBCase {
     producer.registerConnection(connection);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("{\"key\": 1}");
     LifecycleHelper.initAndStart(producer);
-    producer.produce(msg, new ConfiguredDestination(COLLECTION));
+    producer.produce(msg);
     if(localTests){
       assertRecordsArePresent(1);
     } else {

--- a/src/test/java/com/adaptris/core/mongodb/MongoDBFindProducerTest.java
+++ b/src/test/java/com/adaptris/core/mongodb/MongoDBFindProducerTest.java
@@ -16,27 +16,28 @@
 
 package com.adaptris.core.mongodb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import java.util.Arrays;
-import java.util.Collections;
-import org.bson.BsonDocument;
-import org.bson.Document;
-import org.junit.Before;
-import org.junit.Test;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ConfiguredDestination;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.StringPayloadDataInputParameter;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.mongodb.client.FindIterable;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author mwarman
@@ -124,7 +125,7 @@ public class  MongoDBFindProducerTest extends MongoDBCase {
     producer.registerConnection(connection);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
     LifecycleHelper.initAndStart(producer);
-    producer.request(msg, new ConfiguredDestination("collection"), TIMEOUT.toMilliseconds());
+    producer.request(msg, TIMEOUT.toMilliseconds());
     String result = msg.getContent();
     if(!localTests) {
       verify(collection, times(1)).find(new Document());
@@ -140,7 +141,7 @@ public class  MongoDBFindProducerTest extends MongoDBCase {
     producer.registerConnection(connection);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(FILTER);
     LifecycleHelper.initAndStart(producer);
-    producer.request(msg, new ConfiguredDestination("collection"), TIMEOUT.toMilliseconds());
+    producer.request(msg, TIMEOUT.toMilliseconds());
     String result = msg.getContent();
     if(!localTests) {
       verify(collection, times(1)).find(Document.parse(FILTER));
@@ -156,7 +157,7 @@ public class  MongoDBFindProducerTest extends MongoDBCase {
     producer.registerConnection(connection);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     LifecycleHelper.initAndStart(producer);
-    producer.request(msg, new ConfiguredDestination("collection"), TIMEOUT.toMilliseconds());
+    producer.request(msg, TIMEOUT.toMilliseconds());
     String result = msg.getContent();
     if(!localTests) {
       verify(collection, times(1)).find(new Document());
@@ -173,7 +174,7 @@ public class  MongoDBFindProducerTest extends MongoDBCase {
     producer.registerConnection(connection);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     LifecycleHelper.initAndStart(producer);
-    producer.request(msg, new ConfiguredDestination("collection"), TIMEOUT.toMilliseconds());
+    producer.request(msg, TIMEOUT.toMilliseconds());
     String result = msg.getContent();
     if(!localTests) {
       verify(collection, times(1)).find(new Document());
@@ -191,7 +192,7 @@ public class  MongoDBFindProducerTest extends MongoDBCase {
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     msg.addMetadata("limit", LIMIT.toString());
     LifecycleHelper.initAndStart(producer);
-    producer.request(msg, new ConfiguredDestination("collection"), TIMEOUT.toMilliseconds());
+    producer.request(msg, TIMEOUT.toMilliseconds());
     String result = msg.getContent();
     if(!localTests) {
       verify(collection, times(1)).find(new Document());

--- a/src/test/java/com/adaptris/core/mongodb/MongoDBReplaceProducerTest.java
+++ b/src/test/java/com/adaptris/core/mongodb/MongoDBReplaceProducerTest.java
@@ -16,23 +16,24 @@
 
 package com.adaptris.core.mongodb;
 
-import static org.junit.Assert.assertEquals;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.util.LifecycleHelper;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.ReplaceOptions;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ConfiguredDestination;
-import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.util.LifecycleHelper;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.model.ReplaceOptions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author mwarman
@@ -72,7 +73,7 @@ public class MongoDBReplaceProducerTest extends MongoDBCase {
     producer.setUpsert(true);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("[ {\"key\": 1},{\"key\": 2}]");
     LifecycleHelper.initAndStart(producer);
-    producer.produce(msg, new ConfiguredDestination(COLLECTION));
+    producer.produce(msg);
     if(localTests){
       assertRecordsArePresent(2);
     } else {
@@ -90,7 +91,7 @@ public class MongoDBReplaceProducerTest extends MongoDBCase {
     producer.setUpsert(true);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("{\"key\": 1}");
     LifecycleHelper.initAndStart(producer);
-    producer.produce(msg, new ConfiguredDestination(COLLECTION));
+    producer.produce(msg);
     if(localTests){
       assertRecordsArePresent(1);
     } else {
@@ -108,7 +109,7 @@ public class MongoDBReplaceProducerTest extends MongoDBCase {
     producer.setUpsert(false);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("[ {\"key\": 1},{\"key\": 2}]");
     LifecycleHelper.initAndStart(producer);
-    producer.produce(msg, new ConfiguredDestination(COLLECTION));
+    producer.produce(msg);
     if(localTests){
       assertRecordsArePresent(0);
     } else {
@@ -126,7 +127,7 @@ public class MongoDBReplaceProducerTest extends MongoDBCase {
     producer.setUpsert(false);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("{\"key\": 1}");
     LifecycleHelper.initAndStart(producer);
-    producer.produce(msg, new ConfiguredDestination(COLLECTION));
+    producer.produce(msg);
     if(localTests){
       assertRecordsArePresent(0);
     } else {
@@ -143,7 +144,7 @@ public class MongoDBReplaceProducerTest extends MongoDBCase {
     producer.setUpsert(true);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("{\"name\": \"Fred's\", \"stars\": 2}");
     LifecycleHelper.initAndStart(producer);
-    producer.produce(msg, new ConfiguredDestination(COLLECTION));
+    producer.produce(msg);
     if(localTests){
       assertRecordsArePresent(2);
     } else {
@@ -161,7 +162,7 @@ public class MongoDBReplaceProducerTest extends MongoDBCase {
     producer.setValueConverters(Collections.singletonList(new IntegerValueConverter("stars")));
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("{\"name\": \"Fred's\", \"stars\": \"2\"}");
     LifecycleHelper.initAndStart(producer);
-    producer.produce(msg, new ConfiguredDestination(COLLECTION));
+    producer.produce(msg);
     if(localTests){
       assertRecordsArePresent(2);
     } else {

--- a/src/test/java/com/adaptris/core/mongodb/MongoDBUpdateDataTypesProducerTest.java
+++ b/src/test/java/com/adaptris/core/mongodb/MongoDBUpdateDataTypesProducerTest.java
@@ -16,6 +16,27 @@
 
 package com.adaptris.core.mongodb;
 
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.StandaloneProducer;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.StringPayloadDataInputParameter;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.bson.types.Decimal128;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -24,26 +45,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Map;
-import org.bson.Document;
-import org.bson.types.Decimal128;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ConfiguredDestination;
-import com.adaptris.core.StandaloneProducer;
-import com.adaptris.core.common.ConstantDataInputParameter;
-import com.adaptris.core.common.StringPayloadDataInputParameter;
-import com.adaptris.core.util.LifecycleHelper;
-import com.adaptris.interlok.config.DataInputParameter;
-import com.mongodb.client.FindIterable;
-import com.mongodb.client.MongoCollection;
 
 /**
  * @author mwarman
@@ -132,7 +133,7 @@ public class MongoDBUpdateDataTypesProducerTest extends MongoDBCase {
     producer.registerConnection(connection);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
     LifecycleHelper.initAndStart(producer);
-    producer.request(msg, new ConfiguredDestination("collection"), TIMEOUT.toMilliseconds());
+    producer.request(msg, TIMEOUT.toMilliseconds());
     Map<String, Object> result;
     if(!localTests) {
       verify(collection, times(1)).find(Document.parse(FILTER));

--- a/src/test/java/com/adaptris/core/mongodb/MongoDBWriteProducerTest.java
+++ b/src/test/java/com/adaptris/core/mongodb/MongoDBWriteProducerTest.java
@@ -16,17 +16,18 @@
 
 package com.adaptris.core.mongodb;
 
-import static org.junit.Assert.assertEquals;
-import java.util.ArrayList;
-import org.bson.Document;
-import org.junit.Test;
-import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ConfiguredDestination;
 import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.util.LifecycleHelper;
 import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author mwarman
@@ -45,7 +46,7 @@ public class MongoDBWriteProducerTest extends MongoDBCase {
     producer.registerConnection(connection);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("[ {\"key\": 1},{\"key\": 2}]");
     LifecycleHelper.initAndStart(producer);
-    producer.produce(msg, new ConfiguredDestination(COLLECTION));
+    producer.produce(msg);
     if(localTests){
       assertRecordsArePresent(2);
     } else {
@@ -60,7 +61,7 @@ public class MongoDBWriteProducerTest extends MongoDBCase {
     producer.registerConnection(connection);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("{\"key\": 1}");
     LifecycleHelper.initAndStart(producer);
-    producer.produce(msg, new ConfiguredDestination(COLLECTION));
+    producer.produce(msg);
     if(localTests){
       assertRecordsArePresent(1);
     } else {


### PR DESCRIPTION
## Motivation

Removal of deprecated classes in interlok-core force update of optionals.

## Modification

Update/remove references to Destination objects, as they no longer exist.

## Result

The user can no longer use Destinations but has to use whatever the replacement is (here it's likely to be a String)

## Testing

The unit tests should run and pass as before and within the UI the field for Destinations should be removed and an alternative should be present.